### PR TITLE
Wix based installer

### DIFF
--- a/installer/.config/dotnet-tools.json
+++ b/installer/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "wix": {
+      "version": "5.0.0",
+      "commands": [
+        "wix"
+      ]
+    }
+  }
+}

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,0 +1,3 @@
+.wix/
+*.msi
+*.wixpdb

--- a/installer/Installer.wxs
+++ b/installer/Installer.wxs
@@ -9,7 +9,7 @@
 		<?define UpgradeCode = "b776587d-e022-4a12-89ef-bb7f7a1e5145" ?>
 	<?endif?>
 	<!-- This builds a Windows Installer 4.5 MSI - the x64 and x86 versions are considered separate and installed to separate locations because of technical reasons (component rules). -->
-    <Package Name="LCD Smartie $(Suffix)" Version="5.6.0.0" Manufacturer="LCD Smartie Team" UpgradeCode="$(UpgradeCode)" UpgradeStrategy="majorUpgrade" Scope="perUser" InstallerVersion="405">
+	<Package Name="LCD Smartie $(Suffix)" Version="5.6.0.0" Manufacturer="LCD Smartie Team" UpgradeCode="$(UpgradeCode)" UpgradeStrategy="majorUpgrade" Scope="perUser" InstallerVersion="405">
 		<ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
 		<MediaTemplate EmbedCab="yes" />
 		<!-- Required to not clobber config.ini! Note that this requires strict adherence to the component rules, 
@@ -32,5 +32,5 @@
 			</Directory>
 		</StandardDirectory>
 		<WixVariable Id="WixUILicenseRtf" Value="license.rtf" />
-    </Package>
+	</Package>
 </Wix>

--- a/installer/Installer.wxs
+++ b/installer/Installer.wxs
@@ -23,7 +23,7 @@
 						<Exclude Files="..\..\$(ReleaseDir)\config.ini" />
 					</Files>
 					<File Source="$(ReleaseDir)\LCDSmartie.exe">
-						<Shortcut Directory="StartMenuFolder" Name="LCD Smartie $(Suffix)"/>
+						<Shortcut Directory="ProgramMenuFolder" Name="LCD Smartie $(Suffix)"/>
 					</File>
 					<Component Guid="*" NeverOverwrite="yes"> <!-- Never ever overwrite config.ini! It will, however, still be wiped on a repair. -->
 						<File Source="$(ReleaseDir)\config.ini" KeyPath="yes" />

--- a/installer/Installer.wxs
+++ b/installer/Installer.wxs
@@ -1,0 +1,36 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+	<?if $(sys.BUILDARCH) = x64?>
+		<?define ReleaseDir = "..\x64\release-dir" ?>
+		<?define Suffix = "(x64)" ?>
+		<?define UpgradeCode = "c67f8d58-275a-4ec7-9da8-1899e519134e" ?>
+	<?else?>
+		<?define ReleaseDir = "..\release-dir" ?>
+		<?define Suffix = "(x86)" ?>
+		<?define UpgradeCode = "b776587d-e022-4a12-89ef-bb7f7a1e5145" ?>
+	<?endif?>
+	<!-- This builds a Windows Installer 4.5 MSI - the x64 and x86 versions are considered separate and installed to separate locations because of technical reasons (component rules). -->
+    <Package Name="LCD Smartie $(Suffix)" Version="5.6.0.0" Manufacturer="LCD Smartie Team" UpgradeCode="$(UpgradeCode)" UpgradeStrategy="majorUpgrade" Scope="perUser" InstallerVersion="405">
+		<ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
+		<MediaTemplate EmbedCab="yes" />
+		<!-- Required to not clobber config.ini! Note that this requires strict adherence to the component rules, 
+			 see https://learn.microsoft.com/en-us/windows/win32/msi/organizing-applications-into-components -->
+		<MajorUpgrade Schedule="afterInstallExecute" AllowDowngrades="yes" />
+		<StandardDirectory Id="LocalAppDataFolder">
+			<Directory Name="Programs">
+				<Directory Name="LCD Smartie $(Suffix)" Id="INSTALLFOLDER">
+					<Files Include="..\..\$(ReleaseDir)\**">
+						<Exclude Files="..\..\$(ReleaseDir)\LCDSmartie.exe" />
+						<Exclude Files="..\..\$(ReleaseDir)\config.ini" />
+					</Files>
+					<File Source="$(ReleaseDir)\LCDSmartie.exe">
+						<Shortcut Directory="StartMenuFolder" Name="LCD Smartie $(Suffix)"/>
+					</File>
+					<Component Guid="*" NeverOverwrite="yes"> <!-- Never ever overwrite config.ini! It will, however, still be wiped on a repair. -->
+						<File Source="$(ReleaseDir)\config.ini" KeyPath="yes" />
+					</Component>
+				</Directory>
+			</Directory>
+		</StandardDirectory>
+		<WixVariable Id="WixUILicenseRtf" Value="license.rtf" />
+    </Package>
+</Wix>

--- a/installer/build.bat
+++ b/installer/build.bat
@@ -1,0 +1,4 @@
+dotnet tool restore
+dotnet tool run wix -- extension add WixToolset.UI.wixext
+dotnet tool run wix -- build -ext WixToolset.UI.wixext -arch x86 .\Installer.wxs -o installer_x86.msi
+dotnet tool run wix -- build -ext WixToolset.UI.wixext -arch x64 .\Installer.wxs -o installer_x64.msi

--- a/installer/license.rtf
+++ b/installer/license.rtf
@@ -1,0 +1,141 @@
+{\rtf1\ansi\ansicpg1252\uc1\deff0\stshfdbch0\stshfloch0\stshfhich0\stshfbi0\deflang1033\deflangfe1033{\fonttbl{\f0\froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\f2\fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}{\f461\froman\fcharset238\fprq2 Times New Roman CE;}{\f462\froman\fcharset204\fprq2 Times New Roman Cyr;}{\f464\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f465\froman\fcharset162\fprq2 Times New Roman Tur;}{\f466\froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f467\froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f468\froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\f469\froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f481\fmodern\fcharset238\fprq1 Courier New CE;}{\f482\fmodern\fcharset204\fprq1 Courier New Cyr;}{\f484\fmodern\fcharset161\fprq1 Courier New Greek;}
+{\f485\fmodern\fcharset162\fprq1 Courier New Tur;}{\f486\fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f487\fmodern\fcharset178\fprq1 Courier New (Arabic);}{\f488\fmodern\fcharset186\fprq1 Courier New Baltic;}
+{\f489\fmodern\fcharset163\fprq1 Courier New (Vietnamese);}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;
+\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;}{\stylesheet{
+\ql \li0\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 \snext0 Normal;}{
+\s3\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \b\fs27\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext3 \styrsid13916669 heading 3;}{
+\s4\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\outlinelevel3\adjustright\rin0\lin0\itap0 \b\fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext4 \styrsid13916669 heading 4;}{\*\cs10 \additive 
+\ssemihidden Default Paragraph Font;}{\*\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tscellwidthfts0\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv 
+\ql \li0\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \fs20\lang1024\langfe1024\cgrid\langnp1024\langfenp1024 \snext11 \ssemihidden Normal Table;}{\s15\ql \li0\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 
+\f2\fs20\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext15 \styrsid14112014 Plain Text;}{\s16\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 
+\fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext16 \styrsid13916669 Normal (Web);}{\s17\ql \li0\ri0\widctlpar
+\tx916\tx1832\tx2748\tx3664\tx4580\tx5496\tx6412\tx7328\tx8244\tx9160\tx10076\tx10992\tx11908\tx12824\tx13740\tx14656\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \f2\fs20\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 
+\sbasedon0 \snext17 \styrsid13916669 HTML Preformatted;}{\*\cs18 \additive \b \sbasedon10 \styrsid13916669 Strong;}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid596296\rsid8663193\rsid10575444\rsid12061108\rsid13916669\rsid14112014}
+{\*\generator Microsoft Word 10.0.6612;}{\info{\title GNU GENERAL PUBLIC LICENSE}{\creatim\yr2024\mo4\dy16\hr17\min43}{\revtim\yr2024\mo4\dy16\hr17\min49}{\version7}{\edmins6}{\nofpages5}{\nofwords2488}{\nofchars12289}
+{\nofcharsws14771}{\vern16389}}\margl1319\margr1319 \widowctrl\ftnbj\aenddoc\noxlattoyen\expshrtn\noultrlspc\dntblnsbdb\nospaceforul\formshade\horzdoc\dgmargin\dghspace180\dgvspace180\dghorigin1319\dgvorigin1440\dghshow1\dgvshow1
+\jexpand\viewkind1\viewscale100\pgbrdrhead\pgbrdrfoot\splytwnine\ftnlytwnine\htmautsp\nolnhtadjtbl\useltbaln\alntblind\lytcalctblwd\lyttblrtgr\lnbrkrule\nobrkwrptbl\snaptogridincell\allowfieldendsel\wrppunct\asianbrkrule\rsidroot14112014 \fet0\sectd 
+\linex0\headery708\footery708\colsx708\endnhere\sectlinegrid360\sectdefaultcl\sectrsid14112014\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3
+\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}
+{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain 
+\s3\qc \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid8663193 \b\fs27\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 GNU }{\insrsid13916669\charrsid8663193 GEN
+ERAL}{\insrsid13916669  PUBLIC LICENSE
+\par }\pard\plain \qc \li0\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid8663193 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 Version 2, June 1991
+\par }\pard\plain \s15\ql \li0\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid8663193 \f2\fs20\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
+\par 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+\par }\pard\plain \s17\ql \li0\ri0\widctlpar\tx916\tx1832\tx2748\tx3664\tx4580\tx5496\tx6412\tx7328\tx8244\tx9160\tx10076\tx10992\tx11908\tx12824\tx13740\tx14656\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid13916669 
+\f2\fs20\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 
+\par }\pard\plain \s15\ql \li0\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid12061108 \f2\fs20\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 Everyone is permitted to copy and distribute verbatim copies}{
+\insrsid13916669  }{\insrsid13916669 of this license document, but changing it is not allowed.
+\par }\pard\plain \s4\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\outlinelevel3\adjustright\rin0\lin0\itap0\pararsid13916669 \b\fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 Preamble
+\par }\pard\plain \s16\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid13916669 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 The licenses for 
+most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to 
+make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is
+ covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too. 
+\par When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute c
+opies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things. 
+\par To protect y
+our rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it. 
+
+\par For example, i
+f you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they 
+know their rights. 
+\par We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software. 
+\par Also, for each author's protection and ours, we want to 
+make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by 
+others will not reflect on the original authors' reputations. 
+\par Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect maki
+ng the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all. 
+\par The precise terms and conditions for copying, distribution and modification follow. }{\insrsid13916669 
+\par }\pard\plain \s4\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\outlinelevel3\adjustright\rin0\lin0\itap0\pararsid13916669 \b\fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION}{\insrsid13916669 
+\par }\pard\plain \s16\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid13916669 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\cs18\b\insrsid13916669 0.}{\insrsid13916669 
+ This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Pr
+ogram", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modificatio
+ns and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you". 
+\par Activities other than copying, distribution and modification are not covered by this Lice
+nse; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether tha
+t is true depends on what the Program does. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 1.}{\insrsid13916669 
+ You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice
+ and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program. 
+\par You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 2.}{\insrsid13916669  You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modificati
+ons or work under the terms of Section 1 above, provided that you also meet all of these conditions: 
+\par }\pard\plain \ql \li720\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin720\itap0\pararsid13916669 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\cs18\b\insrsid13916669 a)}{\insrsid13916669 
+ You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change. 
+\par }{\cs18\b\insrsid13916669 b)}{\insrsid13916669  You must cause any work
+ that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License. 
+\par }{\cs18\b\insrsid13916669 c)}{\insrsid13916669  If the modified program normally reads c
+ommands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, sayin
+g
+ that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, y
+our work based on the Program is not required to print an announcement.) 
+\par }\pard\plain \s16\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid13916669 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and sepa
+rate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of t
+he whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it. 
+\par Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program. 
+\par In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License. }{
+\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 3.}{\insrsid13916669  You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following: 
+
+\par }\pard\plain \ql \li720\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin720\itap0\pararsid13916669 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\cs18\b\insrsid13916669 a)}{\insrsid13916669 
+ Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or, 
+\par }{\cs18\b\insrsid13916669 b)}{\insrsid13916669  Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy 
+of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or, 
+\par }{\cs18\b\insrsid13916669 c)}{\insrsid13916669  Accompany it with the information you received as to the offer to distribute corresponding source c
+ode. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.) 
+\par }\pard\plain \s16\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid13916669 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid13916669 
+The source code for a work means the preferred form of the
+ work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the 
+e
+xecutable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the e
+xecutable runs, unless that component itself accompanies the executable. 
+\par If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place co
+unts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 4.}{\insrsid13916669  You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any att
+empt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses t
+erminated so long as such parties remain in full compliance. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 5.}{\insrsid13916669  You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These action
+s are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distrib
+uting or modifying the Program or works based on it. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 6.}{\insrsid13916669  Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject t
+o these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 7.}{\insrsid13916669  If, as a consequence of a court judgm
+ent or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the
+ 
+conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license
+ would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program. 
+
+\par If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances. 
+\par It is not the purpose of this section t
+o induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license p
+r
+actices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software
+ through any other system and a licensee cannot impose that choice. 
+\par This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 8.}{\insrsid13916669  If the distribution and/or use of the Program is restricted in certa
+in countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only
+ in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 9.}{\insrsid13916669  The Free Software Foundation may publish revised and/or new versions of the General Public License from time to t
+ime. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. 
+\par Each version is given a distinguishing version number. If the Program specifies a version number of this License which a
+pplies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you
+ may choose any version ever published by the Free Software Foundation. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 10.}{\insrsid13916669  If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. 
+For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free soft
+ware and of promoting the sharing and reuse of software generally. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 NO WARRANTY}{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 11.}{\insrsid13916669  BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE 
+COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS
+ TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION. }{\insrsid13916669 
+\par }{\cs18\b\insrsid13916669 12.}{\insrsid13916669  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIG
+HT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCL
+U
+DING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF S
+UCH DAMAGES. 
+\par }\pard\plain \ql \li0\ri0\widctlpar\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid13916669 \fs24\lang1033\langfe1033\cgrid\langnp1033\langfenp1033 {\insrsid10575444\charrsid13916669 
+\par }}


### PR DESCRIPTION
[Demo build available here](https://1drv.ms/u/s!Al76FPFTGv0_ge5Ey3KI2AsQFJyH0Q?e=tsRSLh). Compatible with XP, assuming the Windows Installer 4.5 redistributable is installed. Works out of the box since Vista.

It creates a shortcut in the start menu, and won't touch config.ini or any added files on updates.

To build is pretty simple - make sure you have a recent [.NET SDK](https://dotnet.microsoft.com/en-us/download), then run `build.bat` in the installer directory. It will build both the 32 and 64 bit installers.

Closes #22.